### PR TITLE
Fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.4.1 (2018-08-11)
+------------------
+
+* Add leading newlines when passing report to ``failure_command``
+
+
 0.4.0 (2018-02-25)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 * Add leading newlines when passing report to ``failure_command``
-
+* In the ``failure_html_path`` global config setting, the string ``{date}`` will be replaced with the current datetime (at time of config load) in ``%Y-%m-%dT%H-%M-%S`` format.
 
 0.4.0 (2018-02-25)
 ------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -51,7 +51,7 @@ The global configuration file or mapping should match the following:
 * **inter_poll_sleep_sec** - *(optional)* how many seconds to sleep between each poll cycle to check the status of asynchronous jobs. Defaults to 10 seconds.
 * **max_total_runtime_sec** - *(optional)* Maximum runtime for each ecsjobs invocation, in seconds. If invocation runs longer than this amount, it will die with an error. Default is 3600 seconds (1 hour).
 * **email_subject** - *(optional)* a string to use for the email report subject, instead of "ECSJobs Report".
-* **failure_html_path** - *(optional)* a string absolute path to write the HTML email report to on disk, if sending via SES fails. If not specified, a temporary file will be used (via Python's ``tempfile.mkstemp``) and its path included in the output.
+* **failure_html_path** - *(optional)* a string absolute path to write the HTML email report to on disk, if sending via SES fails. If not specified, a temporary file will be used (via Python's ``tempfile.mkstemp``) and its path included in the output. If specified, the string ``{date}`` in this setting will be replaced with the current datetime (at time of config load) in ``%Y-%m-%dT%H-%M-%S`` format.
 * **failure_command** - *(optional)* Array. A command to call if sending via SES fails. This should be an array beginning with the absolute path to the executable, suitable for passing to Python's ``subprocess.Popen()``. The content of the HTML report will be passed to the process on STDIN.
 
 Job Schema

--- a/docs/source/ecsjobs.config.rst
+++ b/docs/source/ecsjobs.config.rst
@@ -1,5 +1,5 @@
-ecsjobs\.config module
-======================
+ecsjobs.config module
+=====================
 
 .. automodule:: ecsjobs.config
     :members:

--- a/docs/source/ecsjobs.jobs.base.rst
+++ b/docs/source/ecsjobs.jobs.base.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.base module
-==========================
+ecsjobs.jobs.base module
+========================
 
 .. automodule:: ecsjobs.jobs.base
     :members:

--- a/docs/source/ecsjobs.jobs.docker_exec.rst
+++ b/docs/source/ecsjobs.jobs.docker_exec.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.docker\_exec module
-==================================
+ecsjobs.jobs.docker\_exec module
+================================
 
 .. automodule:: ecsjobs.jobs.docker_exec
     :members:

--- a/docs/source/ecsjobs.jobs.docker_exec_mixin.rst
+++ b/docs/source/ecsjobs.jobs.docker_exec_mixin.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.docker\_exec\_mixin module
-=========================================
+ecsjobs.jobs.docker\_exec\_mixin module
+=======================================
 
 .. automodule:: ecsjobs.jobs.docker_exec_mixin
     :members:

--- a/docs/source/ecsjobs.jobs.ecs_docker_exec.rst
+++ b/docs/source/ecsjobs.jobs.ecs_docker_exec.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.ecs\_docker\_exec module
-=======================================
+ecsjobs.jobs.ecs\_docker\_exec module
+=====================================
 
 .. automodule:: ecsjobs.jobs.ecs_docker_exec
     :members:

--- a/docs/source/ecsjobs.jobs.ecs_task.rst
+++ b/docs/source/ecsjobs.jobs.ecs_task.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.ecs\_task module
-===============================
+ecsjobs.jobs.ecs\_task module
+=============================
 
 .. automodule:: ecsjobs.jobs.ecs_task
     :members:

--- a/docs/source/ecsjobs.jobs.local_command.rst
+++ b/docs/source/ecsjobs.jobs.local_command.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs\.local\_command module
-====================================
+ecsjobs.jobs.local\_command module
+==================================
 
 .. automodule:: ecsjobs.jobs.local_command
     :members:

--- a/docs/source/ecsjobs.jobs.rst
+++ b/docs/source/ecsjobs.jobs.rst
@@ -1,5 +1,5 @@
-ecsjobs\.jobs package
-=====================
+ecsjobs.jobs package
+====================
 
 .. automodule:: ecsjobs.jobs
     :members:

--- a/docs/source/ecsjobs.reporter.rst
+++ b/docs/source/ecsjobs.reporter.rst
@@ -1,5 +1,5 @@
-ecsjobs\.reporter module
-========================
+ecsjobs.reporter module
+=======================
 
 .. automodule:: ecsjobs.reporter
     :members:

--- a/docs/source/ecsjobs.runner.rst
+++ b/docs/source/ecsjobs.runner.rst
@@ -1,5 +1,5 @@
-ecsjobs\.runner module
-======================
+ecsjobs.runner module
+=====================
 
 .. automodule:: ecsjobs.runner
     :members:

--- a/docs/source/ecsjobs.schema.rst
+++ b/docs/source/ecsjobs.schema.rst
@@ -1,5 +1,5 @@
-ecsjobs\.schema module
-======================
+ecsjobs.schema module
+=====================
 
 .. automodule:: ecsjobs.schema
     :members:

--- a/docs/source/ecsjobs.version.rst
+++ b/docs/source/ecsjobs.version.rst
@@ -1,5 +1,5 @@
-ecsjobs\.version module
-=======================
+ecsjobs.version module
+======================
 
 .. automodule:: ecsjobs.version
     :members:

--- a/ecsjobs/config.py
+++ b/ecsjobs/config.py
@@ -39,6 +39,7 @@ import os
 import logging
 import glob
 from copy import copy, deepcopy
+from datetime import datetime
 
 import yaml
 import boto3
@@ -293,6 +294,12 @@ class Config(object):
         """
         Schema().validate(self._raw_conf)
         self._global_conf = self._raw_conf['global']
+        if self._global_conf.get('failure_html_path', None) is not None:
+            self._global_conf[
+                'failure_html_path'
+            ] = self._global_conf[
+                'failure_html_path'
+            ].format(date=datetime.now().strftime('%Y-%m-%dT%H-%M-%S'))
 
     def _make_jobs(self):
         """

--- a/ecsjobs/reporter.py
+++ b/ecsjobs/reporter.py
@@ -126,7 +126,7 @@ class Reporter(object):
                         *failure_cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                         universal_newlines=True
                     )
-                    out = p.communicate(input=report, timeout=120)[0]
+                    out = p.communicate(input='\n\n%s' % report, timeout=120)[0]
                     logger.warning(
                         'Failure command (%s) exited %s with output:\n%s',
                         failure_cmd, p.returncode, out

--- a/ecsjobs/tests/test_reporter.py
+++ b/ecsjobs/tests/test_reporter.py
@@ -353,7 +353,7 @@ class TestRun(ReportTester):
                 '/bin/something', 'foo', stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                 universal_newlines=True
             ),
-            call().communicate(input='my_html_report', timeout=120)
+            call().communicate(input='\n\nmy_html_report', timeout=120)
         ]
         assert mocks['os_close'].mock_calls == [call(999)]
 

--- a/ecsjobs/version.py
+++ b/ecsjobs/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ##################################################################################
 """
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 PROJECT_URL = 'https://github.com/jantman/ecsjobs'


### PR DESCRIPTION
* Add leading newlines when passing report to ``failure_command``
* In the ``failure_html_path`` global config setting, the string ``{date}`` will be replaced with the current datetime (at time of config load) in ``%Y-%m-%dT%H-%M-%S`` format.